### PR TITLE
Scroll player

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -18,7 +18,7 @@ div.spotify-wrapper,
 div.youtube-wrapper {
 	height: 100vh; 
 	color: white;
-	padding-top: 20px!important;
+	width: 100%;
 	/* 
 	vh is a unit of measurement of current viewport (window)
 	1vh == 1% viewport height so 100vh == 100% viewport height. 
@@ -160,9 +160,15 @@ a.disabled {
  	margin-top: 10px;
 }
 
+.spotify-wrapper {
+    padding-left: 1px!important;
+    padding-right: 2px!important;
+}
+
 .player {
 	background-color: black;
 	width: 100%;
+	max-height: 600px;
 }
 
 .playlistImages {
@@ -193,6 +199,13 @@ a.disabled {
  	margin-left: 10px;
  	line-height: 2;
  	width: 97%;
+ }
+
+ .songslist {
+ 	max-height: 450px;
+ 	width: 100%;
+    overflow: scroll;
+    overflow-x: hidden;
  }
 
  .tableBody tr:nth-child(odd) {background-color: #333333}

--- a/assets/javascript/app.js
+++ b/assets/javascript/app.js
@@ -1,4 +1,6 @@
 $(document).ready(function() {
+
+	$('.player').hide();
     /**
      * Generates a string of random numbers and letters
      * @param  {int} length [length of desired string]
@@ -449,6 +451,8 @@ function player() {
 }
 
 function displayPlaylist(item) {
+
+	$('.player').show();
 	
 	var playlistImage = $('<img>', {
     'src': item[0].dataset.img


### PR DESCRIPTION
Hello friends

- The player is now taking the whole width of the spotify-wrapper div

- The player is not exceeding the total height of the container when long playlists are displayed.

- The songs are now scrollable, while the playlist header remains static

* The only thing I couldn't get right yet was the fact that the scroll bar is appearing for shorter playlists as well. I'll work to fix that, any help is appreciated!

Cheeeeers  =)