### PR TITLE
added tabs for  mobile

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -69,6 +69,23 @@ div.row.content::after {
 	text-align: center;
 }
 
+/*-- Tabs Styles --*/
+.tabs {
+ 	background-image: -webkit-linear-gradient(left, #191414 50%, #fff 50%);
+	background-image: -moz-linear-gradient(left, #191414 50%, #fff 50%);
+}
+
+#spot-tab a {
+	color: green;
+}
+
+#yt-tab a {
+	color: red;
+}
+
+.tabs .indicator {
+    background-color: blue;
+}
 
 /* Side Nav Styles */
 /*-------------------------------------------*/
@@ -209,7 +226,7 @@ a.disabled {
  }
  
 .playlistName {
- 	font-size: 40px;
+ 	font-size: 2em;
  }
  
 .songsContainer {
@@ -285,19 +302,6 @@ th:last-of-type {
 	display: none;
 }
 
-
-
-@media only screen and (max-width: 600px) {
-	.spotify-wrapper {
-		float: left;
-		width: 100%;
-	}
-	.youtube-wrapper {
-		float: left;
-		width: 100%;
-		clear: both;
-	}
-}
 footer col
 {
 	padding-bottom: 10px;

--- a/assets/javascript/app.js
+++ b/assets/javascript/app.js
@@ -228,6 +228,8 @@ $(document).ready(function() {
 
     $(".button-collapse").sideNav();
 	
+	switchTabs();
+
     if (/index\.html$/.test(location.href)) {
 
 	    $('.modal').modal({
@@ -477,5 +479,25 @@ function displayPlaylist(item) {
 
 	    $('#modal3').modal('open');
 	    videosData = search(tracksData.tracks);
+	});
+}
+
+function switchTabs() {
+	$('.tab').on('click', function() {
+		let tabClicked = $(this).attr('id');
+
+		if (tabClicked == 'spot-tab') {
+
+			$('#yt-side').addClass('hide-on-small-only');
+
+			$('#spot-side').removeClass('hide-on-small-only');
+
+		} else if (tabClicked == 'yt-tab'){
+
+			$('#spot-side').addClass('hide-on-small-only');
+
+			$('#yt-side').removeClass('hide-on-small-only');
+		}
+
 	});
 }

--- a/index.html
+++ b/index.html
@@ -153,14 +153,22 @@
 	</div>
 	
 	<div class="row content">
-		<div class="col m6 spotify-wrapper grey darken-2">
+
+		<div class="hide-on-med-and-up">
+			<ul class="tabs s12">
+				<li id="spot-tab" class="tab s6"><a>Spotify</a></li>
+				<li id="yt-tab" class="tab s6"><a>YouTube</a></li>
+			</ul>
+		</div>
+
+		<div id="spot-side" class="col m6 spotify-wrapper grey darken-2">
 			<div class="player">
  				<div class="playlistTitle"></div>
  				<div class="songslist"></div>
  			</div>
 		</div>
 
-		<div class="col m6 youtube-wrapper grey lighten-2">
+		<div id="yt-side" class="col m6 youtube-wrapper grey lighten-2">
 			<div class="yt-player-area video-container row">
 				<iframe id="yt-player" src="" frameborder="false" allowfullscreen></iframe>
 			</div>


### PR DESCRIPTION
Tabs for mobile resolutions is added.  It was a bit trickier than I thought couldn't use the built in Materialize tabs as is, because it would change the page to only be rendered inside one of the wrappers (the Spotify side mainly).  So had to add some JS and manipulate the wrappers with some other Materialize classes for hiding, worked out well in the end. There is a issue with some playlist depending on the size of the text in the songs list that will slightly or outright cut-off the last song in the playlist, though this happens even without the tabs in the code. I reduce the size of the Playlist titles slightly with a more responsive em instead of px, which helped but did not outright fix the problem.

![screen shot 2016-11-26 at 12 13 09 am](https://cloud.githubusercontent.com/assets/20407411/20638196/38e71058-b36d-11e6-9195-cd37cab311c5.png)